### PR TITLE
Replace Spaces with Newline

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "pack_format": 15,
-    "description": "Minecraft, upscaled.                §6By Misterk7_-"
+    "description": "Minecraft, upscaled.\n§6By Misterk7_-"
   }
 }


### PR DESCRIPTION
Spaces have no guarantee of hitting the right location, given the fact that Minecraft's font system can handle variable-width letters (like those in my own fonts). I didn't realize you *weren't* using this already until I looked through things extra carefully recently.