### PR TITLE
Replace README Coloring Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Following will be a list that's meant to be indicative on the progress and to-do
 | Cave spider                 | $\small\color{green}\textsf{Fixed}$     | Touchups and consistency w/ spider |
 | Chest & Large Chest         | $\small\color{green}\textsf{Fixed}$     | Consistency tweaks                 |
 | Trapped Chest & Large Chest | $\small\color{green}\textsf{Fixed}$     | Consistency tweaks                 |
-| Minecart                    | $\small\color{green}\textsf{Fixed}$     | Side texture needs remake          |
+| Minecart                    | $\small\color{orange}\textsf{Fixed}$    | Side texture needs remake          |
 | Chicken                     | $\small\color{green}\textsf{Fixed}$     | Redo feet                          |
 | Dolphin                     | $\small\color{green}\textsf{Fixed}$     | Eyes to standard                   |
 | Enchantment Table           | $\small\color{orange}\textsf{OK}$       | Redo Book                          |

--- a/README.md
+++ b/README.md
@@ -1,71 +1,70 @@
 # vanillaxbr
 Repository for managing updates to my Minecraft resource pack.
 
-This is entity-dev. Initially based on the 1.20.1 branch. Development here is dedicated to remaking and improving old and existing entities in the game. This is something I intend on doing over a period of time seperate to the main releases, so i've branched it off here. 
+This is entity-dev. Initially based on the 1.20.1 branch. Development here is dedicated to remaking and improving old and existing entities in the game. This is something I intend on doing over a period of time seperate to the main releases, so i've branched it off here.
 
-Following will be a list that's meant to be indicative on the progress and to-dos I have to do here: 
+Following will be a list that's meant to be indicative on the progress and to-dos I have to do here:
 
-| Entity                      | State                                  | Note                               |
-|-----------------------------|----------------------------------------|------------------------------------|
-| Blaze                       | <p style="color: green;">Fixed</p>     | Eyes to standard                   |
-| Cave spider                 | <p style="color: green;">Fixed</p>     | Touchups and consistency w/ spider |
-| Chest & Large Chest         | <p style="color: green;">Fixed</p>     | Consistency tweaks                 |
-| Trapped Chest & Large Chest | <p style="color: green;">Fixed</p>     | Consistency tweaks                 |
-| Minecart                    | <p style="color: orange;">Fixed</p>    | Side texture needs remake          |
-| Chicken                     | <p style="color: green;">Fixed</p>     | Redo feet                          |
-| Dolphin                     | <p style="color: green;">Fixed</p>     | Eyes to standard                   |
-| Enchantment Table           | <p style="color: orange;">OK</p>       | Redo Book                          |
-| Enderman                    | <p style="color: orange;">OK</p>       | Eyes to standard                   |
-| Evoker                      | <p style="color: orange;">OK</p>       | Redo; All illagers consistent face |
-| Guardian                    | <p style="color: orange;">OK</p>       | Tweak spikes                       |
-| Elder Guardian              | <p style="color: orange;">OK</p>       | Tweak spikes                       |
-| Hoglin                      | <p style="color: orange;">OK</p>       | Eyes to standard                   |
-| Illusioner                  | <p style="color: orange;">OK</p>       | Redo; All illagers consistent face |
-| Magma cube                  | <p style="color: orange;">OK</p>       | Redo                               |
-| Polar bear                  | <p style="color: orange;">OK</p>       | Eyes to standard                   |
-| Silverfish                  | <p style="color: orange;">OK</p>       | Needs tweaking                     |
-| Skeleton                    | <p style="color: orange;">OK</p>       | Redo ribcage                       |
-| Snowman                     | <p style="color: orange;">OK</p>       | Redo                               |
-| Husk                        | <p style="color: orange;">OK</p>       | Redo w/ skele consistency          |
-| Vindicator                  | <p style="color: orange;">OK</p>       | Redo; All illagers consistent face |
-| Wither Skeleton             | <p style="color: orange;">OK</p>       | Redo chest                         |
-| Wolf                        | <p style="color: orange;">OK</p>       | May need to tweak puppy eyes       |
-| Zoglin                      | <p style="color: orange;">OK</p>       | Eyes consistency                   |
-| Zombie                      | <p style="color: orange;">OK</p>       | Redo                               |
-| Zombified Piglin            | <p style="color: orange;">OK</p>       | Redo with piglin consistency       |
-|                             |                                        |                                    |
-| Cat                         | <p style="color: red;">Bad</p>         | All needs redoing                  |
-| Cod                         | <p style="color: red;">Bad</p>         | Redo                               |
-| Conduit                     | <p style="color: red;">Bad</p>         | Redo                               |
-| Donkey                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Ender Dragon                | <p style="color: purple;">Passable</p> | Eyes to standard                   |
-| Drowned                     | <p style="color: red;">Bad</p>         | Redo                               |
-| End Crystal                 | <p style="color: red;">Bad</p>         | Redo                               |
-| Evoker Fangs                | <p style="color: red;">Bad</p>         | Redo                               |
-| Fox                         | <p style="color: red;">Bad</p>         | Redo                               |
-| Horses                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Iron Golem                  | <p style="color: red;">Bad</p>         | Redo                               |
-| llama                       | <p style="color: red;">Bad</p>         | Redo                               |
-| Mooshroom                   | <p style="color: red;">Bad</p>         | Consistency with Cow red           |
-| Mule                        | <p style="color: red;">Bad</p>         | Redo                               |
-| Ocelot                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Panda                       | <p style="color: red;">Bad</p>         | Redo                               |
-| Parrot                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Phantom                     | <p style="color: red;">Bad</p>         | Redo hqnx                          |
-| Pig                         | <p style="color: red;">Bad</p>         | Good but redo saddle               |
-| Piglin                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Piglin Brute                | <p style="color: red;">Bad</p>         | Redo                               |
-| Pillager                    | <p style="color: red;">Bad</p>         | Redo; All illagers consistent face |
-| Pufferfish                  | <p style="color: red;">Bad</p>         | Redo                               |
-| Ravager                     | <p style="color: red;">Bad</p>         | Redo                               |
-| Pufferfish                  | <p style="color: red;">Bad</p>         | Redo                               |
-| Salmon                      | <p style="color: red;">Bad</p>         | Redo                               |
-| Shulker                     | <p style="color: red;">Bad</p>         | Redo                               |
-| Skeleton Horse              | <p style="color: red;">Bad</p>         | Redo                               |
-| Trader Llama                | <p style="color: red;">Bad</p>         | Redo                               |
-| Tropical Fish               | <p style="color: red;">Bad</p>         | Redo                               |
-| Villager                    | <p style="color: red;">Bad</p>         | BIG REDO                           |
-| Witch                       | <p style="color: red;">Bad</p>         | Redo                               |
-| Zombie Horse                | <p style="color: red;">Bad</p>         | Redo                               |
-| Zombie Villager             | <p style="color: red;">Bad</p>         | BIG REDO                           |
-|                             |                                        |                                    |
+| Entity                      | State                                   | Note                               |
+|-----------------------------|-----------------------------------------|------------------------------------|
+| Blaze                       | $\small\color{green}\textsf{Fixed}$     | Eyes to standard                   |
+| Cave spider                 | $\small\color{green}\textsf{Fixed}$     | Touchups and consistency w/ spider |
+| Chest & Large Chest         | $\small\color{green}\textsf{Fixed}$     | Consistency tweaks                 |
+| Trapped Chest & Large Chest | $\small\color{green}\textsf{Fixed}$     | Consistency tweaks                 |
+| Minecart                    | $\small\color{green}\textsf{Fixed}$     | Side texture needs remake          |
+| Chicken                     | $\small\color{green}\textsf{Fixed}$     | Redo feet                          |
+| Dolphin                     | $\small\color{green}\textsf{Fixed}$     | Eyes to standard                   |
+| Enchantment Table           | $\small\color{orange}\textsf{OK}$       | Redo Book                          |
+| Enderman                    | $\small\color{orange}\textsf{OK}$       | Eyes to standard                   |
+| Evoker                      | $\small\color{orange}\textsf{OK}$       | Redo; All illagers consistent face |
+| Guardian                    | $\small\color{orange}\textsf{OK}$       | Tweak spikes                       |
+| Elder Guardian              | $\small\color{orange}\textsf{OK}$       | Tweak spikes                       |
+| Hoglin                      | $\small\color{orange}\textsf{OK}$       | Eyes to standard                   |
+| Illusioner                  | $\small\color{orange}\textsf{OK}$       | Redo; All illagers consistent face |
+| Magma cube                  | $\small\color{orange}\textsf{OK}$       | Redo                               |
+| Polar bear                  | $\small\color{orange}\textsf{OK}$       | Eyes to standard                   |
+| Silverfish                  | $\small\color{orange}\textsf{OK}$       | Needs tweaking                     |
+| Skeleton                    | $\small\color{orange}\textsf{OK}$       | Redo ribcage                       |
+| Snowman                     | $\small\color{orange}\textsf{OK}$       | Redo                               |
+| Husk                        | $\small\color{orange}\textsf{OK}$       | Redo w/ skele consistency          |
+| Vindicator                  | $\small\color{orange}\textsf{OK}$       | Redo; All illagers consistent face |
+| Wither Skeleton             | $\small\color{orange}\textsf{OK}$       | Redo chest                         |
+| Wolf                        | $\small\color{orange}\textsf{OK}$       | May need to tweak puppy eyes       |
+| Zoglin                      | $\small\color{orange}\textsf{OK}$       | Eyes consistency                   |
+| Zombie                      | $\small\color{orange}\textsf{OK}$       | Redo                               |
+| Zombified Piglin            | $\small\color{orange}\textsf{OK}$       | Redo with piglin consistency       |
+|                             |                                         |                                    |
+| Cat                         | $\small\color{red}\textsf{Bad}$         | All needs redoing                  |
+| Cod                         | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Conduit                     | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Donkey                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Ender Dragon                | $\small\color{purple}\textsf{Passable}$ | Eyes to standard                   |
+| Drowned                     | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| End Crystal                 | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Evoker Fangs                | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Fox                         | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Horses                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Iron Golem                  | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| llama                       | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Mooshroom                   | $\small\color{red}\textsf{Bad}$         | Consistency with Cow red           |
+| Mule                        | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Ocelot                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Panda                       | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Parrot                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Phantom                     | $\small\color{red}\textsf{Bad}$         | Redo hqnx                          |
+| Pig                         | $\small\color{red}\textsf{Bad}$         | Good but redo saddle               |
+| Piglin                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Piglin Brute                | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Pillager                    | $\small\color{red}\textsf{Bad}$         | Redo; All illagers consistent face |
+| Pufferfish                  | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Ravager                     | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Pufferfish                  | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Salmon                      | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Shulker                     | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Skeleton Horse              | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Trader Llama                | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Tropical Fish               | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Villager                    | $\small\color{red}\textsf{Bad}$         | BIG REDO                           |
+| Witch                       | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Zombie Horse                | $\small\color{red}\textsf{Bad}$         | Redo                               |
+| Zombie Villager             | $\small\color{red}\textsf{Bad}$         | BIG REDO                           |


### PR DESCRIPTION
Your attempt to add coloring to the ToDo table in the README in the `entity-dev` branch simply does not work. GitHub's web interface does not support using HTML to color text.

![Table Before](https://github.com/mistrk7/vanillaxbr/assets/69320464/e3aa4c35-46be-4af7-88ac-8e47aa5984f9)

However, guess what GitHub's web interface _does_ support for special text formatting, including text sizing, font specifications, and text coloring? LaTeX!

This PR replaces the faulty HTML in the README with LaTeX that I have tested, and confirmed _does_ appear correctly in the GitHub web interface.

![Table After](https://github.com/mistrk7/vanillaxbr/assets/69320464/11a499d1-8cf3-4b43-a10c-c86abd168555)